### PR TITLE
Change AbstractTest.getJobString() to use %n instead of hardcoding \n

### DIFF
--- a/src/test/java/org/launchcode/techjobs/oo/AbstractTest.java
+++ b/src/test/java/org/launchcode/techjobs/oo/AbstractTest.java
@@ -68,12 +68,12 @@ public class AbstractTest {
     }
 
     protected String getJobString (Job job) throws NoSuchMethodException, ClassNotFoundException, InvocationTargetException, IllegalAccessException, NoSuchFieldException {
-        return String.format("\nID: %d\n" +
-                        "Name: %s\n" +
-                        "Employer: %s\n" +
-                        "Location: %s\n" +
-                        "Position Type: %s\n" +
-                        "Core Competency: %s\n", getJobId(job), getJobFieldString(job, "name", true), getJobFieldString(job, "employer", true), getJobFieldString(job, "location", true),
+        return String.format("%nID: %d%n" +
+                        "Name: %s%n" +
+                        "Employer: %s%n" +
+                        "Location: %s%n" +
+                        "Position Type: %s%n" +
+                        "Core Competency: %s%n", getJobId(job), getJobFieldString(job, "name", true), getJobFieldString(job, "employer", true), getJobFieldString(job, "location", true),
                 getJobFieldString(job, "positionType", true), getJobFieldString(job, "coreCompetency", true));
     }
 

--- a/src/test/java/org/launchcode/techjobs/oo/TestTaskFive.java
+++ b/src/test/java/org/launchcode/techjobs/oo/TestTaskFive.java
@@ -10,8 +10,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import static java.lang.System.lineSeparator;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * Created by LaunchCode
@@ -36,10 +35,9 @@ public class TestTaskFive extends AbstractTest {
     @Test
     public void testToStringStartsAndEndsWithNewLine() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
         Job job = createJob("Web Developer", "LaunchCode", "StL", "Back-end developer", "Java");
-        String firstChar = String.valueOf(job.toString().charAt(0));
-        String lastChar = String.valueOf(job.toString().charAt(job.toString().length()-1));
-        assertEquals(firstChar, lineSeparator());
-        assertEquals(lastChar, lineSeparator());
+        String jobString = job.toString();
+        assertTrue(jobString.startsWith(lineSeparator()));
+        assertTrue(jobString.endsWith(lineSeparator()));
     }
 
     @Test


### PR DESCRIPTION
This fixes three tests on Window systems because the students are instructed to use System.lineSeparator() but \n != \r\n, or the test assumed a single character line separator.